### PR TITLE
Code examples before contributors

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,9 +12,9 @@
 
       <a class="sidebar-nav-item{% if page.url == '/' %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
 
-      <a class="sidebar-nav-item{% if page.url == '/contributors/' %} active{% endif %}" href="{{ site.baseurl }}/contributors">Contributors</a>
-
       <a class="sidebar-nav-item{% if page.url == '/examples/' %} active{% endif %}" href="{{ site.baseurl }}/examples">Code Examples</a>
+
+      <a class="sidebar-nav-item{% if page.url == '/contributors/' %} active{% endif %}" href="{{ site.baseurl }}/contributors">Contributors</a>
 
       <a class="sidebar-nav-item{% if page.url == '/errata/' %} active{% endif %}" href="{{ site.baseurl }}/errata">Errata</a>
 


### PR DESCRIPTION
A user would (probably) care more about getting to examples before checking list of authors and editors.

As a bonus, its also now alphabetical!