### PR TITLE
Omit output section

### DIFF
--- a/examples_autogenerated/autogenerate.jl
+++ b/examples_autogenerated/autogenerate.jl
@@ -14,6 +14,7 @@ function collect_examples(oscardir::String)
         for m in eachmatch(r"# INSERT_EXAMPLE (\S*)", entire)
             codefile = m[1]
             code = read(joinpath(booktestdir, codefile), String)
+            code = split(code, "# output")[1]
             println(codefile)
             if !endswith(code, "\n")
                 code *= "\n"

--- a/examples_autogenerated/cornerstones/algebraic-geometry.md
+++ b/examples_autogenerated/cornerstones/algebraic-geometry.md
@@ -754,8 +754,6 @@ function dual_curve(f::MPolyRingElem, P_dual::MPolyRing)
   return dual_curve[1]
 end
 
-# output
-dual_curve (generic function with 1 method)
 ```
 
 ```julia

--- a/examples_autogenerated/cornerstones/groups.md
+++ b/examples_autogenerated/cornerstones/groups.md
@@ -171,11 +171,11 @@ julia> G = dihedral_group(6)
 Pc group of order 6
 
 julia> U = sub(G, [g for g in gens(G) if order(g) == 2])[1]
-Pc group of order 2
+Subgroup of pc group of order 2
 
 julia> r = right_cosets(G, U)
 Right cosets of
-  pc group of order 2 in
+  subgroup of pc group of order 2 in
   pc group of order 6
 
 julia> acting_group(r)

--- a/examples_autogenerated/cornerstones/number-theory.md
+++ b/examples_autogenerated/cornerstones/number-theory.md
@@ -129,8 +129,6 @@ y2 = (x -> max(0, sqrt(3)*x - sqrt(3))).(x);
 p = scatter(real.(pts), imag.(pts), framestyle=:origin,
             legend = false, mc = :red)
 plot!(p, x, y1, fillrange = y2, fillalpha = 0.25, color = :blue)
-# output
-Plot{Plots.GRBackend() n=2}
 ```
 
 ```julia
@@ -144,8 +142,6 @@ plot!(x, [y1 -y1 y2 -y2], color = :black)
 units = [(1, 0), (-1, 0), (2, 1), (-2, 1), (-2, -1),
          (2, -1), (7, 4), (7, -4), (-7, 4), (-7, -4)];
 scatter!(units, color = :red)
-# output
-Plot{Plots.GRBackend() n=6}
 ```
 
 ```julia
@@ -157,8 +153,6 @@ scatter(pts, framestyle=:origin, leg = false, mc = :blue, alpha = 0.25)
 x = range(-3, 3, 100); y = -x; plot!(x, y, color = :black)
 units = [ i .* l(2, 1) for i in -2:2]
 scatter!(units, color = :red)
-# output
-Plot{Plots.GRBackend() n=3}
 ```
 
 ```julia
@@ -326,8 +320,6 @@ G, C = galois_group(K)
 subsG = subgroups(G)
 H = first(H for H in subsG if order(H) == 27)
 k, = simplify(fixed_field(C, H))
-# output
-(Number field of degree 8 over QQ, Map: k -> number field)
 ```
 
 ```julia
@@ -487,12 +479,6 @@ for i in 1:8, j in 1:number_of_small_groups(i)
   println(i, " ", j, " ", describe(G), ": ", locally_free_class_group(ZG))
 end
 
-# output
-┌ Warning: Assignment to `G` in soft scope is ambiguous because a global variable by the same name exists: `G` will be treated as a new local. Disambiguate by using `local G` to suppress this warning or `global G` to assign to the existing global variable.
-└ @ none:2
-6 1 S3: Z/1
-8 3 D8: Z/1
-8 4 Q8: Z/2
 ```
 
 ```julia
@@ -509,7 +495,4 @@ for F in abelian_normal_extensions(k, [2], ZZ(10)^13)
   end
   push!(candidates, K)
 end
-# output
-┌ Warning: Assignment to `K` in soft scope is ambiguous because a global variable by the same name exists: `K` will be treated as a new local. Disambiguate by using `local K` to suppress this warning or `global K` to assign to the existing global variable.
-└ @ none:2
 ```

--- a/examples_autogenerated/cornerstones/polyhedral-geometry.md
+++ b/examples_autogenerated/cornerstones/polyhedral-geometry.md
@@ -186,8 +186,6 @@ using Plots
 scatter(g_vectors[:,1], g_vectors[:,2],
         xlabel="g_2", ylabel="g_3", legend=false);
 
-# output
-Plot{Plots.GRBackend() n=1}
 ```
 
 ```julia


### PR DESCRIPTION
When I revamped the script I forgot that it is supposed to remove the `#output` section from the examples.