### PR TITLE
Update contacts of Johannes Schmitt

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -172,10 +172,10 @@ contributors:
     website: https://victoriaschleis.github.io/
 
   - name: Johannes Schmitt
-    affiliation: University of Siegen
+    affiliation: Ruhr-Universität Bochum
     website: https://joschmitt.eu
     github: joschmitt
-    email: johannes2.schmitt@uni-siegen.de
+    email: johannes.schmitt@ruhr-uni-bochum.de
 
   - name: Frank-Olaf Schreyer
     affiliation: Saarland University


### PR DESCRIPTION
@joschmitt Based on your message in slack, are those changes as desired? Your website told me this email address btw, whereas you wrote in slack to send emails to [johannes.schmitt@rub.de](mailto:johannes.schmitt@rub.de). I assume both work. Preferences?

(Please submit a corresponding PR in the future to update your details.)